### PR TITLE
Fix issue # 41 and issue # 42

### DIFF
--- a/lib/readers/json_script_reader.py
+++ b/lib/readers/json_script_reader.py
@@ -190,10 +190,9 @@ class JSONScriptReader:
                     command["args"] = args
 
                 if "function" in command:
-                    params = None if command is None else command.get("params")
+                    params = command.get("params", None)
                     params = self.sanitize_args(params)
-                    if params is not None:
-                        command["params"] = params
+                    command["params"] = params
 
                     inline_commands = self.resolve_function(command["function"], command["params"], self.functions)
                     if inline_commands is None:


### PR DESCRIPTION
Fix issue #41 by correcting assignment to `params`
Fix issue #42 by always assigning `params` back to `command["params"]`, so that key is guaranteed to be present.